### PR TITLE
Fetch submodules

### DIFF
--- a/assets/buildspec.yml
+++ b/assets/buildspec.yml
@@ -13,12 +13,22 @@ phases:
     commands:
       - echo Entered the pre_build phase...
       - echo Current directory is $CODEBUILD_SRC_DIR
-      - ls
+      - ls -la
       - export dirname=${PWD##*/}
       - echo Directory name $dirname
       - cd ..
       - mv $dirname $PROJECTNAME
-      - ls
+      - ls -la
+      - cd $PROJECTNAME
+      - git config --global url."https://github.com/".insteadOf "git@github.com:"
+      - git init
+      - git remote add origin https://$GITHUBTOKEN@github.com/$GITHUBUSER/$PROJECTNAME.git
+      - git fetch
+      - git checkout -ft origin/develop
+      - git submodule init
+      - git submodule update --recursive
+      - ls -lR
+      - cd ..
       - echo Installing Taskcat using pip3...
       - pip install taskcat==0.7.19
       - echo Verifying Taskcat installation...
@@ -45,4 +55,4 @@ phases:
         fi
 
 ## Single line version
-# "version: 0.2\n\nphases:\n  install:\n    commands:\n      - echo Entered the install phase...\n      - apt-get update -y\n      - sudo apt-get install zip gzip tar -y\n      - pip3 install --upgrade pip\n      - ln -s /usr/local/bin/pip /usr/bin/pip\n  pre_build:\n    commands:\n      - echo Entered the pre_build phase...\n      - echo Current directory is $CODEBUILD_SRC_DIR\n      - ls\n      - export dirname=${PWD##*/}\n      - echo Directory name $dirname\n      - cd ..\n      - mv $dirname $PROJECTNAME\n      - ls\n      - echo Installing Taskcat using pip3...\n      - pip install taskcat==0.7.19\n      - echo Verifying Taskcat installation...\n      - taskcat\n      - echo Configuring aws cli...\n      - aws configure set default.region us-west-2\n  build:\n    commands:\n      - echo Entered the build phase...\n      - taskcat -c $PROJECTNAME/ci/taskcat.yml\n      - ls -1 taskcat_outputs\n      - ls -1 taskcat_outputs | while read LOG; do cat taskcat_outputs/${LOG}; done\n      - echo Zipping and uploading report to $ARTIFACT_BUCKET S3 bucket\n      - zip -r taskcat_report.zip taskcat_outputs\n      - aws s3 cp taskcat_report.zip s3://$ARTIFACT_BUCKET/taskcat_reports/$CODEBUILD_BUILD_ID.zip\n      - |\n        if $(grep -Fq \"CREATE_FAILED\" taskcat_outputs/index.html)\n        then\n          echo Quickstart FAILED!\n          exit 1\n        else\n          echo Quickstart Passed!\n          exit 0\n        fi\n"
+# "version: 0.2\n\nphases:\n  install:\n    commands:\n      - echo Entered the install phase...\n      - apt-get update -y\n      - sudo apt-get install zip gzip tar -y\n      - pip3 install --upgrade pip\n      - ln -s /usr/local/bin/pip /usr/bin/pip\n  pre_build:\n    commands:\n      - echo Entered the pre_build phase...\n      - echo Current directory is $CODEBUILD_SRC_DIR\n      - ls -la\n      - export dirname=${PWD##*/}\n      - echo Directory name $dirname\n      - cd ..\n      - mv $dirname $PROJECTNAME\n      - ls -la\n      - cd $PROJECTNAME\n      - git config --global url.\"https://github.com/\".insteadOf \"git@github.com:\"\n      - git init\n      - git remote add origin https://$GITHUBTOKEN@github.com/$GITHUBUSER/$PROJECTNAME.git\n      - git fetch\n      - git checkout -ft origin/develop\n      - git submodule init\n      - git submodule update --recursive\n      - ls -lR\n      - cd ..\n      - echo Installing Taskcat using pip3...\n      - pip install taskcat==0.7.19\n      - echo Verifying Taskcat installation...\n      - taskcat\n      - echo Configuring aws cli...\n      - aws configure set default.region us-west-2\n  build:\n    commands:\n      - echo Entered the build phase...\n      - taskcat -c $PROJECTNAME/ci/taskcat.yml\n      - ls -1 taskcat_outputs\n      - ls -1 taskcat_outputs | while read LOG; do cat taskcat_outputs/${LOG}; done\n      - echo Zipping and uploading report to $ARTIFACT_BUCKET S3 bucket\n      - zip -r taskcat_report.zip taskcat_outputs\n      - aws s3 cp taskcat_report.zip s3://$ARTIFACT_BUCKET/taskcat_reports/$CODEBUILD_BUILD_ID.zip\n      - |\n        if $(grep -Fq \"CREATE_FAILED\" taskcat_outputs/index.html)\n        then\n          echo Quickstart FAILED!\n          exit 1\n        else\n          echo Quickstart Passed!\n          exit 0\n        fi\n"

--- a/templates/taskcat-ci-pipeline.template
+++ b/templates/taskcat-ci-pipeline.template
@@ -230,6 +230,16 @@
               "Fn::Sub" : "${GitHubRepoName}"
             }
           }, {
+            "Name" : "GITHUBUSER",
+            "Value" : {
+              "Fn::Sub" : "${GitHubUser}"
+            }
+          }, {
+            "Name" : "GITHUBTOKEN",
+            "Value" : {
+              "Fn::Sub" : "${GitHubOAuthToken}"
+            }
+          }, {
             "Name" : "ARTIFACT_BUCKET",
             "Value" : {
               "Ref" : "ArtifactBucket"
@@ -238,7 +248,7 @@
         },
         "Source" : {
           "Type" : "CODEPIPELINE",
-          "BuildSpec" : "version: 0.2\n\nphases:\n  install:\n    commands:\n      - echo Entered the install phase...\n      - apt-get update -y\n      - sudo apt-get install zip gzip tar -y\n      - pip3 install --upgrade pip\n      - ln -s /usr/local/bin/pip /usr/bin/pip\n  pre_build:\n    commands:\n      - echo Entered the pre_build phase...\n      - echo Current directory is $CODEBUILD_SRC_DIR\n      - ls\n      - export dirname=${PWD##*/}\n      - echo Directory name $dirname\n      - cd ..\n      - mv $dirname $PROJECTNAME\n      - ls\n      - echo Installing Taskcat using pip3...\n      - pip install taskcat==0.7.27\n      - echo Verifying Taskcat installation...\n      - taskcat\n      - echo Configuring aws cli...\n      - aws configure set default.region us-west-2\n  build:\n    commands:\n      - echo Entered the build phase...\n      - taskcat -c $PROJECTNAME/ci/taskcat.yml\n      - ls -1 taskcat_outputs\n      - ls -1 taskcat_outputs | while read LOG; do cat taskcat_outputs/${LOG}; done\n      - echo Zipping and uploading report to $ARTIFACT_BUCKET S3 bucket\n      - zip -r taskcat_report.zip taskcat_outputs\n      - aws s3 cp taskcat_report.zip s3://$ARTIFACT_BUCKET/taskcat_reports/$CODEBUILD_BUILD_ID.zip\n      - |\n        if $(grep -Fq \"CREATE_FAILED\" taskcat_outputs/index.html)\n        then\n          echo Quickstart FAILED!\n          exit 1\n        else\n          echo Quickstart Passed!\n          exit 0\n        fi\n"
+          "BuildSpec" : "version: 0.2\n\nphases:\n  install:\n    commands:\n      - echo Entered the install phase...\n      - apt-get update -y\n      - sudo apt-get install zip gzip tar -y\n      - pip3 install --upgrade pip\n      - ln -s /usr/local/bin/pip /usr/bin/pip\n  pre_build:\n    commands:\n      - echo Entered the pre_build phase...\n      - echo Current directory is $CODEBUILD_SRC_DIR\n      - ls -la\n      - export dirname=${PWD##*/}\n      - echo Directory name $dirname\n      - cd ..\n      - mv $dirname $PROJECTNAME\n      - ls -la\n      - cd $PROJECTNAME\n      - git config --global url.\"https://github.com/\".insteadOf \"git@github.com:\"\n      - git init\n      - git remote add origin https://$GITHUBTOKEN@github.com/$GITHUBUSER/$PROJECTNAME.git\n      - git fetch\n      - git checkout -ft origin/develop\n      - git submodule init\n      - git submodule update --recursive\n      - ls -lR\n      - cd ..\n      - echo Installing Taskcat using pip3...\n      - pip install taskcat==0.7.19\n      - echo Verifying Taskcat installation...\n      - taskcat\n      - echo Configuring aws cli...\n      - aws configure set default.region us-west-2\n  build:\n    commands:\n      - echo Entered the build phase...\n      - taskcat -c $PROJECTNAME/ci/taskcat.yml\n      - ls -1 taskcat_outputs\n      - ls -1 taskcat_outputs | while read LOG; do cat taskcat_outputs/${LOG}; done\n      - echo Zipping and uploading report to $ARTIFACT_BUCKET S3 bucket\n      - zip -r taskcat_report.zip taskcat_outputs\n      - aws s3 cp taskcat_report.zip s3://$ARTIFACT_BUCKET/taskcat_reports/$CODEBUILD_BUILD_ID.zip\n      - |\n        if $(grep -Fq \"CREATE_FAILED\" taskcat_outputs/index.html)\n        then\n          echo Quickstart FAILED!\n          exit 1\n        else\n          echo Quickstart Passed!\n          exit 0\n        fi\n"
         }
       }
     },


### PR DESCRIPTION
By default, github source action of AWS Codepipeline doesn't fetch the submodules of the github repo. This PR fixes it by initializing the git repo at the build phase and fetching the submodules.
