### PR TITLE
Enable code-commit as source type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+taskcat_outputs

--- a/ci/input-params-codecommit.json
+++ b/ci/input-params-codecommit.json
@@ -1,0 +1,26 @@
+[
+  {
+    "ParameterKey": "CodeCommitRepoName",
+    "ParameterValue": "quickstart-ci-repo"
+  },
+  {
+    "ParameterKey": "CodeCommitRepoUrl",
+    "ParameterValue": "https://git-codecommit.us-west-2.amazonaws.com/v1/repos/quickstart-ci-repo"
+  },
+  {
+    "ParameterKey": "SourceBranch",
+    "ParameterValue": "develop"
+  },
+  {
+    "ParameterKey": "ReleaseBranch",
+    "ParameterValue": "master"
+  },
+  {
+    "ParameterKey": "QSS3BucketName",
+    "ParameterValue": "$[taskcat_autobucket]"
+  },
+  {
+    "ParameterKey": "QSS3KeyPrefix",
+    "ParameterValue": "quickstart-taskcat-ci/"
+  }
+]

--- a/ci/taskcat.yml
+++ b/ci/taskcat.yml
@@ -19,16 +19,16 @@ global:
   reporting: true
  
 tests:
-  # quickstart-taskcat-ci-test1:
-  #   parameter_input: input-params1.json
-  #   template_file: taskcat-ci-pipeline.template
-  #   regions:
-  #     - us-east-1
-  #     - us-east-2
-  #     - us-west-1
-  #     - us-west-2
-  code-commit-pipeline-test:
-    parameter_input: input-params-codecommit.json
-    template_file: taskcat-ci-pipeline.yaml.template
+  quickstart-taskcat-ci-test1:
+    parameter_input: input-params1.json
+    template_file: taskcat-ci-pipeline.template
     regions:
+      - us-east-1
+      - us-east-2
+      - us-west-1
       - us-west-2
+  # code-commit-pipeline-test:
+  #   parameter_input: input-params-codecommit.json
+  #   template_file: taskcat-ci-pipeline.yaml.template
+  #   regions:
+  #     - us-west-2

--- a/ci/taskcat.yml
+++ b/ci/taskcat.yml
@@ -19,16 +19,16 @@ global:
   reporting: true
  
 tests:
-  quickstart-taskcat-ci-test1:
-    parameter_input: input-params1.json
-    template_file: taskcat-ci-pipeline.template
-    regions:
-      - us-east-1
-      - us-east-2
-      - us-west-1
-      - us-west-2
-  # code-commit-pipeline-test:
-  #   parameter_input: input-params-codecommit.json
-  #   template_file: taskcat-ci-pipeline.yaml.template
+  # quickstart-taskcat-ci-test1:
+  #   parameter_input: input-params1.json
+  #   template_file: taskcat-ci-pipeline.template
   #   regions:
+  #     - us-east-1
+  #     - us-east-2
+  #     - us-west-1
   #     - us-west-2
+  code-commit-pipeline-test:
+    parameter_input: input-params-codecommit.json
+    template_file: taskcat-ci-pipeline.yaml.template
+    regions:
+      - us-west-2

--- a/ci/taskcat.yml
+++ b/ci/taskcat.yml
@@ -27,3 +27,8 @@ tests:
       - us-east-2
       - us-west-1
       - us-west-2
+  # code-commit-pipeline-test:
+  #   parameter_input: input-params-codecommit.json
+  #   template_file: taskcat-ci-pipeline.yaml.template
+  #   regions:
+  #     - us-west-2

--- a/templates/empty-bucket.yaml.template
+++ b/templates/empty-bucket.yaml.template
@@ -1,0 +1,146 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  This template empty the given S3 bucket
+
+Parameters:
+  BucketName:
+    Description: Name of the S3 Bucket which needs to be emptied
+    Type: String
+    
+Resources:
+  CleanUpS3Bucket:
+    Properties:
+      DestBucket: !Ref BucketName
+      ServiceToken: !GetAtt 
+        - CleanUpS3BucketFunction
+        - Arn
+    DependsOn: CleanUpS3BucketFunction
+    Type: 'AWS::CloudFormation::CustomResource'
+  CleanUpS3BucketFunction:
+    Properties:
+      Code:
+        ZipFile: !Join 
+          - |+
+
+          - - import json
+            - import logging
+            - import threading
+            - import boto3
+            - import cfnresponse
+            - client = boto3.client('s3')
+            - ''
+            - ''
+            - 'def delete_NonVersionedobjects(bucket):'
+            - '    print("Collecting data from" + bucket)'
+            - '    paginator =     client.get_paginator(''list_objects_v2'')'
+            - '    result = paginator.paginate(Bucket=bucket)'
+            - '    objects = []'
+            - '    for page in result:'
+            - '        try:'
+            - '            for k in page[''Contents'']:'
+            - '                objects.append({''Key'': k[''Key'']})'
+            - '                print("deleting objects")'
+            - '                client.delete_objects(Bucket=bucket, Delete={''Objects'': objects})'
+            - '                objects = []'
+            - '        except:'
+            - '            pass'
+            - '            print("bucket is already empty")'
+            - ''
+            - 'def delete_versionedobjects(bucket):'
+            - '    print("Collecting data from" + bucket)'
+            - '    paginator = client.get_paginator(''list_object_versions'')'
+            - '    result = paginator.paginate(Bucket=bucket)'
+            - '    objects = []'
+            - '    for page in result:'
+            - '        try:'
+            - '            for k in page[''Versions'']:'
+            - '                objects.append({''Key'':k[''Key''],''VersionId'': k[''VersionId'']})'
+            - '            try:'
+            - '                for k in page[''DeleteMarkers'']:'
+            - '                    version = k[''VersionId'']'
+            - '                    key = k[''Key'']'
+            - '                    objects.append({''Key'': key,''VersionId'': version})'
+            - '            except:'
+            - '                pass'
+            - '            print("deleting objects")'
+            - '            client.delete_objects(Bucket=bucket, Delete={''Objects'': objects})'
+            - '           # objects = []'
+            - '        except:'
+            - '            pass'
+            - '    print("bucket already empty")'
+            - ''
+            - ''
+            - ''
+            - 'def timeout(event, context):'
+            - '    logging.error(''Execution is about to time out, sending failure response to CloudFormation'')'
+            - '    cfnresponse.send(event, context, cfnresponse.FAILED, {}, None)'
+            - ''
+            - ''
+            - 'def handler(event, context):'
+            - '    # make sure we send a failure to CloudFormation if the function is going to timeout'
+            - '    timer = threading.Timer((context.get_remaining_time_in_millis() / 1000.00) - 0.5, timeout, args=[event, context])'
+            - '    timer.start()'
+            - ''
+            - '    print(''Received event: %s'' % json.dumps(event))'
+            - '    status = cfnresponse.SUCCESS'
+            - '    try:'
+            - '        dest_bucket = event[''ResourceProperties''][''DestBucket'']'
+            - '        if event[''RequestType''] == ''Delete'':'
+            - '            CheckifVersioned = client.get_bucket_versioning(Bucket=dest_bucket)'
+            - '            print CheckifVersioned'
+            - '            if ''Status'' in CheckifVersioned:'
+            - '                print CheckifVersioned[''Status'']'
+            - '                print ("This is a versioned Bucket")'
+            - '                delete_versionedobjects(dest_bucket)'
+            - '            else:'
+            - '                print "This is not a versioned bucket"'
+            - '                delete_NonVersionedobjects(dest_bucket)'
+            - '        else:'
+            - '            print("Nothing to do")'
+            - '    except Exception as e:'
+            - '        logging.error(''Exception: %s'' % e, exc_info=True)'
+            - '        status = cfnresponse.FAILED'
+            - '    finally:'
+            - '        timer.cancel()'
+            - '        cfnresponse.send(event, context, status, {}, None)'
+            - ''
+      Description: Empty the S3 Bucket
+      Handler: index.handler
+      Role: !GetAtt 
+        - S3CleanUpRole
+        - Arn
+      Runtime: python2.7
+      Timeout: 240
+    DependsOn: S3CleanUpRole
+    Type: 'AWS::Lambda::Function'
+  S3CleanUpRole:
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: 2012-10-17
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+      Path: /
+      Policies:
+        - PolicyDocument:
+            Statement:
+              - Action:
+                  - 's3:PutObject'
+                  - 's3:DeleteObject'
+                  - 's3:GetObject'
+                  - 's3:ListBucket'
+                  - 's3:ListBucketVersions'
+                  - 's3:DeleteObjectVersion'
+                  - 's3:GetObjectVersion'
+                  - 's3:GetBucketVersioning'
+                Effect: Allow
+                Resource:
+                  - !Sub 'arn:aws:s3:::${BucketName}/*'
+                  - !Sub 'arn:aws:s3:::*'
+            Version: 2012-10-17
+          PolicyName: Empty-bucket
+    Type: 'AWS::IAM::Role'

--- a/templates/iam-roles.yaml.template
+++ b/templates/iam-roles.yaml.template
@@ -1,0 +1,100 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Creates IAM roles for TaskCat CI.
+Resources:
+  CodeBuildServiceRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: ''
+            Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+            Action: 'sts:AssumeRole'
+      Path: /
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/AdministratorAccess'
+  CodePipelineServiceRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: ''
+            Effect: Allow
+            Principal:
+              Service: codepipeline.amazonaws.com
+            Action: 'sts:AssumeRole'
+      Path: /
+      Policies:
+        - PolicyName: !Sub 'TaskCat-CICD-CodePipelineService-${AWS::Region}'
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Action:
+                  - 's3:GetObject'
+                  - 's3:GetObjectVersion'
+                  - 's3:GetBucketVersioning'
+                  - 's3:PutObject'
+                Resource:
+                  - !Sub 'arn:aws:s3:::${ArtifactBucket}'
+                  - !Sub 'arn:aws:s3:::${ArtifactBucket}/*'
+                Effect: Allow
+              - Action:
+                  - 'cloudformation:CreateStack'
+                  - 'cloudformation:DeleteStack'
+                  - 'cloudformation:DescribeStacks'
+                  - 'cloudformation:UpdateStack'
+                  - 'cloudformation:CreateChangeSet'
+                  - 'cloudformation:DeleteChangeSet'
+                  - 'cloudformation:DescribeChangeSet'
+                  - 'cloudformation:ExecuteChangeSet'
+                  - 'cloudformation:SetStackPolicy'
+                  - 'cloudformation:ValidateTemplate'
+                  - 'iam:PassRole'
+                Resource: '*'
+                Effect: Allow
+              - Action:
+                  - 'codebuild:BatchGetBuilds'
+                  - 'codebuild:StartBuild'
+                Resource: '*'
+                Effect: Allow
+              - Action:
+                  - 'lambda:GetPolicy'
+                  - 'lambda:ListEventSourceMappings'
+                  - 'lambda:ListFunctions'
+                  - 'lambda:InvokeFunction'
+                  - 'lambda:GetEventSourceMapping'
+                  - 'lambda:GetFunction'
+                  - 'lambda:ListAliases'
+                  - 'lambda:GetAlias'
+                  - 'lambda:ListTags'
+                  - 'lambda:ListVersionsByFunction'
+                  - 'lambda:GetAccountSettings'
+                  - 'lambda:GetFunctionConfiguration'
+                Resource: '*'
+                Effect: Allow
+              - Action:
+                  - 'codecommit:*'
+                Resource: '*'
+                Effect: Allow
+Parameters:
+  ArtifactBucket:
+    AllowedPattern: '^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$'
+    ConstraintDescription: >-
+      Quick Start bucket name can include numbers, lowercase letters, uppercase
+      letters, and hyphens (-). It cannot start or end with a hyphen (-).
+    Description: S3 bucket name used to store build artifacts.
+    Type: String
+Outputs:
+  CodePipelineRoleArn:
+    Description: Code Pipeline service role arn
+    Value: !GetAtt 
+      - CodePipelineServiceRole
+      - Arn
+  CodeBuildRoleArn:
+    Description: Code Build service role arn
+    Value: !GetAtt 
+      - CodeBuildServiceRole
+      - Arn

--- a/templates/pipeline.yaml.template
+++ b/templates/pipeline.yaml.template
@@ -145,7 +145,7 @@ Resources:
                     - ls -R
                     - cd ..
                     - echo Installing Taskcat using pip3...
-                    - pip install taskcat==0.8.49
+                    - pip install taskcat==0.9.1
                     - echo Verifying Taskcat installation...
                     - taskcat
                     - echo Configuring aws cli...
@@ -153,7 +153,8 @@ Resources:
             build:
                 commands:
                     - echo Entered the build phase...
-                    - taskcat -c $PROJECTNAME/ci/taskcat.yml
+                    - cd $PROJECTNAME
+                    - taskcat test run -l
                     - ls -1 taskcat_outputs
                     - ls -1 taskcat_outputs | while read LOG; do cat taskcat_outputs/$LOG; done
                     - |

--- a/templates/pipeline.yaml.template
+++ b/templates/pipeline.yaml.template
@@ -1,0 +1,206 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Creates Pipeline for TaskCat CI.
+
+Resources:
+  CloudwatchEventRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: ''
+            Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: 'sts:AssumeRole'
+      Path: /service-role/
+      Policies:
+        - PolicyName: !Sub 'TaskCat-CICD-EventsInvoke-${AWS::Region}'
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Action:
+                  - 'codepipeline:StartPipelineExecution'
+                Resource:
+                  - !Join [ '', [ 'arn:aws:codepipeline:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref CodePipeline ] ]
+                Effect: Allow
+  TriggerPipelineCWEventRule:
+    Type: AWS::Events::Rule
+    Properties: 
+      Description: "Cloudwatch event rule to trigger codepipeline on commint on code commit repo"
+      EventPattern:
+        source:
+          - aws.codecommit
+        detail-type:
+          - 'CodeCommit Repository State Change'
+        resources:
+          - !Join [ '', [ 'arn:aws:codecommit:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref CodeCommitRepoName ] ]
+        detail:
+          referenceType:
+            - branch
+          referenceName:
+            - !Ref SourceBranch
+      State: ENABLED
+      Targets:
+        -
+          Arn:
+            !Join [ '', [ 'arn:aws:codepipeline:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':', !Ref CodePipeline ] ]
+          RoleArn: !GetAtt CloudwatchEventRole.Arn
+          Id: build-pipeline
+  CodePipeline:
+    Type: 'AWS::CodePipeline::Pipeline'
+    Properties:
+      ArtifactStore:
+        Type: S3
+        Location: !Ref ArtifactBucket
+      RoleArn: !Ref CodePipelineRoleArn
+      Stages:
+        - Name: Source
+          Actions:
+            - Name: AWS-Code-Commit
+              InputArtifacts: []
+              ActionTypeId:
+                Category: Source
+                Owner: AWS
+                Version: '1'
+                Provider: CodeCommit
+              OutputArtifacts:
+                - Name: code-commit-source
+              Configuration:
+                PollForSourceChanges: 'false'
+                RepositoryName: !Ref CodeCommitRepoName
+                BranchName: !Ref SourceBranch
+              RunOrder: 1
+        - Name: Build
+          Actions:
+            - Name: CodeBuild
+              InputArtifacts:
+                - Name: code-commit-source
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Version: '1'
+                Provider: CodeBuild
+              OutputArtifacts: []
+              Configuration:
+                ProjectName: !Ref CodeBuild
+              RunOrder: 2
+  CodeBuild:
+    Type: 'AWS::CodeBuild::Project'
+    Properties:
+      Description: !Sub 'Submit build jobs for ${CodeCommitRepoName} as part of CI/CD pipeline'
+      ServiceRole: !Ref CodeBuildRoleArn
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: 'aws/codebuild/standard:1.0'
+        EnvironmentVariables:
+          - Name: REPOURL
+            Value: !Sub '${CodeCommitRepoUrl}'
+          - Name: PROJECTNAME
+            Value: !Sub '${CodeCommitRepoName}'
+          - Name: SOURCEBRANCH
+            Value: !Sub '${SourceBranch}'
+          - Name: RELEASEBRANCH
+            Value: !Sub '${ReleaseBranch}'
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: !Sub |
+          version: 0.2
+
+          env:
+              git-credential-helper: yes
+          phases:
+            install:
+                commands:
+                    - echo Entered the install phase...
+                    - apt-get update -y
+                    - apt-get install zip gzip tar -y
+                    - pip3 install --upgrade pip awscli
+                    - ln -s /usr/local/bin/pip /usr/bin/pip
+            pre_build:
+                commands:
+                    - echo Entered the pre_build phase...
+                    - echo Current directory is $CODEBUILD_SRC_DIR
+                    - ls -la
+                    - cd ..
+                    - echo $REPOURL
+                    - echo $PROJECTNAME $SOURCEBRANCH $RELEASEBRANCH
+                    - git clone $REPOURL
+                    - cd $PROJECTNAME
+                    - git checkout $SOURCEBRANCH
+                    - |
+                        if [ ! -z "$CODEBUILD_RESOLVED_SOURCE_VERSION:-" ]
+                        then
+                            echo source version - $CODEBUILD_RESOLVED_SOURCE_VERSION
+                            git reset $CODEBUILD_RESOLVED_SOURCE_VERSION
+                        else
+                            echo No source version found
+                            git pull
+                        fi
+                    - git config --global url."https://github.com/".insteadOf "git@github.com:"
+                    - git submodule update --init --recursive
+                    - ls -R
+                    - cd ..
+                    - echo Installing Taskcat using pip3...
+                    - pip install taskcat==0.8.49
+                    - echo Verifying Taskcat installation...
+                    - taskcat
+                    - echo Configuring aws cli...
+                    - aws configure set default.region us-west-2
+            build:
+                commands:
+                    - echo Entered the build phase...
+                    - taskcat -c $PROJECTNAME/ci/taskcat.yml
+                    - ls -1 taskcat_outputs
+                    - ls -1 taskcat_outputs | while read LOG; do cat taskcat_outputs/$LOG; done
+                    - |
+                        if $(grep -Fq "CREATE_FAILED" taskcat_outputs/index.html)
+                        then
+                        echo Quickstart FAILED!
+                        exit 1
+                        else
+                        echo Quickstart Passed!
+                        exit 0
+                        fi
+                    - echo Merging branch develop into master..
+                    - aws codecommit merge-branches-by-fast-forward --source-commit-specifier $SOURCEBRANCH --destination-commit-specifier $RELEASEBRANCH --repository-name $PROJECTNAME
+                    - echo Merge Successfull !!
+Parameters:
+  CodeCommitRepoName:
+    Description: Enter the repository name that should be monitored for changes
+    Type: String
+  CodeCommitRepoUrl:
+    Description: >-
+      AWS Code commit repository URL which will be monitored for CI/CD. Provide
+      https:// endpoint of the repo.
+    Type: String
+  SourceBranch:
+    Description: Enter the branch name to be monitored
+    Type: String
+    Default: develop
+  ReleaseBranch:
+    Description: >-
+      Enter the release branch name. On successfull build, above branch will be
+      merged into this branch.
+    Type: String
+    Default: master
+  ArtifactBucket:
+    AllowedPattern: '^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$'
+    ConstraintDescription: >-
+      Quick Start bucket name can include numbers, lowercase letters, uppercase
+      letters, and hyphens (-). It cannot start or end with a hyphen (-).
+    Description: S3 bucket name used to store build artifacts.
+    Type: String
+  CodePipelineRoleArn:
+    Description: Code Pipeline service role ARN
+    Type: String
+  CodeBuildRoleArn:
+    Description: Code Build service role ARN
+    Type: String
+Outputs:
+  CodePipelineName:
+    Description: Pipeline  name
+    Value: !Ref CodePipeline

--- a/templates/taskcat-ci-pipeline.yaml.template
+++ b/templates/taskcat-ci-pipeline.yaml.template
@@ -1,0 +1,138 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Creates Pipeline and required resources for TaskCat CI. License: Apache 2.0
+  (Please do not remove)(qs-1ops82lkf)
+
+Resources:
+  ArtifactBucket:
+    Type: 'AWS::S3::Bucket'
+    Properties:
+      AccessControl: Private
+      LifecycleConfiguration:
+        Rules:
+          - NoncurrentVersionExpirationInDays: 30
+            Status: Enabled
+      VersioningConfiguration:
+        Status: Enabled
+  EmptyBucketLambdaStack:
+    Type: 'AWS::CloudFormation::Stack'
+    DependsOn:
+      - ArtifactBucket
+    Properties:
+      TemplateURL: !Sub >-
+        https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}templates/empty-bucket.yaml.template
+      Parameters:
+        BucketName: !Ref ArtifactBucket
+  IAMRoleStack:
+    Type: 'AWS::CloudFormation::Stack'
+    DependsOn:
+      - ArtifactBucket
+    Properties:
+      TemplateURL: !Sub >-
+        https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}templates/iam-roles.yaml.template
+      Parameters:
+        ArtifactBucket: !Ref ArtifactBucket
+  CodePipelineStack:
+    Type: 'AWS::CloudFormation::Stack'
+    DependsOn:
+      - ArtifactBucket
+      - IAMRoleStack
+    Properties:
+      TemplateURL: !Sub >-
+        https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}templates/pipeline.yaml.template
+      Parameters:
+        CodeCommitRepoName: !Ref CodeCommitRepoName
+        CodeCommitRepoUrl: !Ref CodeCommitRepoUrl
+        SourceBranch: !Ref SourceBranch
+        ReleaseBranch: !Ref ReleaseBranch
+        ArtifactBucket: !Ref ArtifactBucket
+        CodePipelineRoleArn: !GetAtt 
+          - IAMRoleStack
+          - Outputs.CodePipelineRoleArn
+        CodeBuildRoleArn: !GetAtt 
+          - IAMRoleStack
+          - Outputs.CodeBuildRoleArn
+
+Parameters:
+  CodeCommitRepoName:
+    Description: Enter the repository name that should be monitored for changes
+    Type: String
+  CodeCommitRepoUrl:
+    Description: >-
+      AWS Code commit repository URL which will be monitored for CI/CD. Provide
+      https:// endpoint of the repo.
+    Type: String
+  SourceBranch:
+    Description: Enter the branch name to be monitored
+    Type: String
+    Default: develop
+  ReleaseBranch:
+    Description: >-
+      Enter the release branch name. On successfull build, above branch will be
+      merged into this branch.
+    Type: String
+    Default: master
+  QSS3BucketName:
+    AllowedPattern: '^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$'
+    ConstraintDescription: >-
+      Quick Start bucket name can include numbers, lowercase letters, uppercase
+      letters, and hyphens (-). It cannot start or end with a hyphen (-).
+    Default: aws-quickstart
+    Description: >-
+      S3 bucket name for the Quick Start assets. Quick Start bucket name can
+      include numbers, lowercase letters, uppercase letters, and hyphens (-). It
+      cannot start or end with a hyphen (-).
+    Type: String
+  QSS3KeyPrefix:
+    AllowedPattern: '^[0-9a-zA-Z-/]*$'
+    ConstraintDescription: >-
+      Quick Start key prefix can include numbers, lowercase letters, uppercase
+      letters, hyphens (-), and forward slash (/).
+    Default: quickstart-taskcat-ci/
+    Description: >-
+      S3 key prefix for the Quick Start assets. Quick Start key prefix can
+      include numbers, lowercase letters, uppercase letters, hyphens (-), and
+      forward slash (/).
+    Type: String
+
+Metadata:
+  'AWS::CloudFormation::Interface':
+    ParameterGroups:
+      - Label:
+          default: AWS Code Commit Configuration
+        Parameters:
+          - CodeCommitRepoName
+          - CodeCommitRepoUrl
+          - SourceBranch
+          - ReleaseBranch
+      - Label:
+          default: AWS Quick Start Configuration
+        Parameters:
+          - QSS3BucketName
+          - QSS3KeyPrefix
+    ParameterLabels:
+      CodeCommitRepoUrl:
+        default: Repository URL
+      CodeCommitRepoName:
+        default: Repository name
+      SourceBranch:
+        default: Source branch
+      ReleaseBranch:
+        default: Release branch
+      QSS3BucketName:
+        default: Quick Start S3 Bucket Name
+      QSS3KeyPrefix:
+        default: Quick Start S3 Key Prefix
+
+Outputs:
+  CodePipelineURL:
+    Description: The URL of the created Pipeline
+    Value: !Sub 
+      - >-
+        https://${AWS::Region}.console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/${CodePipelineName}
+      - CodePipelineName: !GetAtt 
+          - CodePipelineStack
+          - Outputs.CodePipelineName
+  TaskCatReports:
+    Description: Path to the TaskCat report. Each report is named as CODEBUILD_BUILD_ID.zip
+    Value: !Sub 's3://${ArtifactBucket}/taskcat_reports/'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add templates to enable AWS code commit as source repo
- Use Taskcat V9 in codebuild for testing CFN templates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
