### PR TITLE
Refactor empty bucket code/upgrade to python 3.8

### DIFF
--- a/templates/copy-lambdas.template
+++ b/templates/copy-lambdas.template
@@ -43,7 +43,7 @@ Resources:
       - LambdaZipsBucket
       - CopyObjectsFunction
     Properties:
-      ServiceToken: !GetAtt 
+      ServiceToken: !GetAtt
         - CopyObjectsFunction
         - Arn
       DestBucket: !Ref LambdaZipsBucket
@@ -55,87 +55,92 @@ Resources:
   CopyObjectsFunction:
     Properties:
       Code:
-        ZipFile: !Join 
-          - |+
+        ZipFile: |
+          #!/usr/bin/env python3
+          import json
+          import logging
+          import threading
+          import boto3
+          import cfnresponse
+          client = boto3.client('s3')
 
-          - - import json
-            - import logging
-            - import threading
-            - import boto3
-            - import cfnresponse
-            - ''
-            - ''
-            - 'def copy_objects(source_bucket, dest_bucket, prefix, objects):'
-            - '    s3 = boto3.client(''s3'')'
-            - '    for o in objects:'
-            - '        key = prefix + o'
-            - '        copy_source = {'
-            - '            ''Bucket'': source_bucket,'
-            - '            ''Key'': key'
-            - '        }'
-            - '        s3.copy_object(CopySource=copy_source, Bucket=dest_bucket, Key=key)'
-            - ''
-            - ''
-            - 'def delete_objects(bucket):'
-            - '    client = boto3.client(''s3'')'
-            - '    print("Collecting data from" + bucket)'
-            - '    paginator = client.get_paginator(''list_object_versions'')'
-            - '    result = paginator.paginate(Bucket=bucket)'
-            - '    objects = []'
-            - '    for page in result:'
-            - '        try:'
-            - '            for k in page[''Versions'']:'
-            - '                objects.append({''Key'':k[''Key''],''VersionId'': k[''VersionId'']})'
-            - '            try:'
-            - '                for k in page[''DeleteMarkers'']:'
-            - '                    version = k[''VersionId'']'
-            - '                    key = k[''Key'']'
-            - '                    objects.append({''Key'': key,''VersionId'': version})'
-            - '            except:'
-            - '                pass'
-            - '            print("deleting objects")'
-            - '            client.delete_objects(Bucket=bucket,     Delete={''Objects'': objects})'
-            - '           # objects = []'
-            - '        except:'
-            - '            pass'
-            - '    print("bucket already empty")'
-            - ''
-            - ''
-            - ''
-            - 'def timeout(event, context):'
-            - '    logging.error(''Execution is about to time out, sending failure response to CloudFormation'')'
-            - '    cfnresponse.send(event, context, cfnresponse.FAILED, {}, None)'
-            - ''
-            - ''
-            - 'def handler(event, context):'
-            - '    # make sure we send a failure to CloudFormation if the function is going to timeout'
-            - '    timer = threading.Timer((context.get_remaining_time_in_millis() / 1000.00) - 0.5, timeout, args=[event, context])'
-            - '    timer.start()'
-            - ''
-            - '    print(''Received event: %s'' % json.dumps(event))'
-            - '    status = cfnresponse.SUCCESS'
-            - '    try:'
-            - '        source_bucket = event[''ResourceProperties''][''SourceBucket'']'
-            - '        dest_bucket = event[''ResourceProperties''][''DestBucket'']'
-            - '        prefix = event[''ResourceProperties''][''Prefix'']'
-            - '        objects = event[''ResourceProperties''][''Objects'']'
-            - '        if event[''RequestType''] == ''Delete'':'
-            - '            delete_objects(dest_bucket)'
-            - '        else:'
-            - '            copy_objects(source_bucket, dest_bucket, prefix, objects)'
-            - '    except Exception as e:'
-            - '        logging.error(''Exception: %s'' % e, exc_info=True)'
-            - '        status = cfnresponse.FAILED'
-            - '    finally:'
-            - '        timer.cancel()'
-            - '        cfnresponse.send(event, context, status, {}, None)'
-            - ''
+
+          def delete_non_versioned_objects(bucket):
+              print('Collecting data from' + bucket)
+              paginator = client.get_paginator('list_objects_v2')
+              result = paginator.paginate(Bucket=bucket)
+              delete_objects(bucket, result)
+
+
+          def delete_versioned_objects(bucket):
+              print('Collecting data from' + bucket)
+              paginator = client.get_paginator('list_object_versions')
+              result = paginator.paginate(Bucket=bucket)
+              delete_objects(bucket, result)
+
+
+          def delete_objects(bucket, result):
+              objects = []
+              for page in result:
+                  if 'Contents' in page:
+                      for k in page['Contents']:
+                          objects.append({'Key': k['Key']})
+                  if 'Versions' in page:
+                      for k in page['Versions']:
+                          objects.append({'Key': k['Key'], 'VersionId': k['VersionId']})
+                  if 'DeleteMarkers' in page:
+                      for k in page['DeleteMarkers']:
+                          version = k['VersionId']
+                          key = k['Key']
+                          objects.append({'Key': key, 'VersionId': version})
+              print('deleting objects')
+              try:
+                  client.delete_objects(Bucket=bucket, Delete={'Objects': objects})
+              except Exception as e:
+                  logging.error('Exception deleting objects: %s' % e)
+                  raise
+              print('bucket emptied')
+
+
+          def timeout(event, context):
+              logging.error('Lambda execution has timed out, sending failure response to CloudFormation')
+              logging.error('Consider increasing the Lambda execution timeout parameter in the configuration')
+              cfnresponse.send(event, context, cfnresponse.FAILED, {}, None)
+
+
+          def handler(event, context):
+              # make sure we send a failure to CloudFormation if the function is going to timeout
+              timer = threading.Timer((context.get_remaining_time_in_millis() / 1000.00) - 0.5, timeout, args=[event, context])
+              timer.start()
+
+              print('Received event: %s' % json.dumps(event))
+              status = cfnresponse.SUCCESS
+              try:
+                  dest_bucket = event['ResourceProperties']['DestBucket']
+                  if event['RequestType'] == 'Delete':
+                      CheckifVersioned = client.get_bucket_versioning(Bucket=dest_bucket)
+                      print(CheckifVersioned)
+                      if 'Status' in CheckifVersioned:
+                          print(CheckifVersioned['Status'])
+                          print('This is a versioned Bucket')
+                          delete_versioned_objects(dest_bucket)
+                      else:
+                          print('This is not a versioned bucket')
+                          delete_non_versioned_objects(dest_bucket)
+                  else:
+                      print('Nothing to do')
+              except Exception as e:
+                  logging.error('Exception: %s' % e, exc_info=True)
+                  status = cfnresponse.FAILED
+              finally:
+                  timer.cancel()
+                  cfnresponse.send(event, context, status, {}, None)
       Description: Copies objects from a source S3 bucket to a destination S3 bucket
       Handler: index.handler
       Role: !GetAtt 
         - CopyObjectsRole
         - Arn
-      Runtime: python2.7
+      Runtime: python3.8
       Timeout: 240
     DependsOn:
       - CopyObjectsRole

--- a/templates/empty-bucket.yaml.template
+++ b/templates/empty-bucket.yaml.template
@@ -1,12 +1,10 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
   This template empty the given S3 bucket
-
 Parameters:
   BucketName:
     Description: Name of the S3 Bucket which needs to be emptied
     Type: String
-    
 Resources:
   CleanUpS3Bucket:
     Properties:
@@ -19,97 +17,92 @@ Resources:
   CleanUpS3BucketFunction:
     Properties:
       Code:
-        ZipFile: !Join 
-          - |+
+        ZipFile: |
+          #!/usr/bin/env python3
+          import json
+          import logging
+          import threading
+          import boto3
+          import cfnresponse
+          client = boto3.client('s3')
 
-          - - import json
-            - import logging
-            - import threading
-            - import boto3
-            - import cfnresponse
-            - client = boto3.client('s3')
-            - ''
-            - ''
-            - 'def delete_NonVersionedobjects(bucket):'
-            - '    print("Collecting data from" + bucket)'
-            - '    paginator =     client.get_paginator(''list_objects_v2'')'
-            - '    result = paginator.paginate(Bucket=bucket)'
-            - '    objects = []'
-            - '    for page in result:'
-            - '        try:'
-            - '            for k in page[''Contents'']:'
-            - '                objects.append({''Key'': k[''Key'']})'
-            - '                print("deleting objects")'
-            - '                client.delete_objects(Bucket=bucket, Delete={''Objects'': objects})'
-            - '                objects = []'
-            - '        except:'
-            - '            pass'
-            - '            print("bucket is already empty")'
-            - ''
-            - 'def delete_versionedobjects(bucket):'
-            - '    print("Collecting data from" + bucket)'
-            - '    paginator = client.get_paginator(''list_object_versions'')'
-            - '    result = paginator.paginate(Bucket=bucket)'
-            - '    objects = []'
-            - '    for page in result:'
-            - '        try:'
-            - '            for k in page[''Versions'']:'
-            - '                objects.append({''Key'':k[''Key''],''VersionId'': k[''VersionId'']})'
-            - '            try:'
-            - '                for k in page[''DeleteMarkers'']:'
-            - '                    version = k[''VersionId'']'
-            - '                    key = k[''Key'']'
-            - '                    objects.append({''Key'': key,''VersionId'': version})'
-            - '            except:'
-            - '                pass'
-            - '            print("deleting objects")'
-            - '            client.delete_objects(Bucket=bucket, Delete={''Objects'': objects})'
-            - '           # objects = []'
-            - '        except:'
-            - '            pass'
-            - '    print("bucket already empty")'
-            - ''
-            - ''
-            - ''
-            - 'def timeout(event, context):'
-            - '    logging.error(''Execution is about to time out, sending failure response to CloudFormation'')'
-            - '    cfnresponse.send(event, context, cfnresponse.FAILED, {}, None)'
-            - ''
-            - ''
-            - 'def handler(event, context):'
-            - '    # make sure we send a failure to CloudFormation if the function is going to timeout'
-            - '    timer = threading.Timer((context.get_remaining_time_in_millis() / 1000.00) - 0.5, timeout, args=[event, context])'
-            - '    timer.start()'
-            - ''
-            - '    print(''Received event: %s'' % json.dumps(event))'
-            - '    status = cfnresponse.SUCCESS'
-            - '    try:'
-            - '        dest_bucket = event[''ResourceProperties''][''DestBucket'']'
-            - '        if event[''RequestType''] == ''Delete'':'
-            - '            CheckifVersioned = client.get_bucket_versioning(Bucket=dest_bucket)'
-            - '            print CheckifVersioned'
-            - '            if ''Status'' in CheckifVersioned:'
-            - '                print CheckifVersioned[''Status'']'
-            - '                print ("This is a versioned Bucket")'
-            - '                delete_versionedobjects(dest_bucket)'
-            - '            else:'
-            - '                print "This is not a versioned bucket"'
-            - '                delete_NonVersionedobjects(dest_bucket)'
-            - '        else:'
-            - '            print("Nothing to do")'
-            - '    except Exception as e:'
-            - '        logging.error(''Exception: %s'' % e, exc_info=True)'
-            - '        status = cfnresponse.FAILED'
-            - '    finally:'
-            - '        timer.cancel()'
-            - '        cfnresponse.send(event, context, status, {}, None)'
-            - ''
+
+          def delete_non_versioned_objects(bucket):
+              print('Collecting data from' + bucket)
+              paginator = client.get_paginator('list_objects_v2')
+              result = paginator.paginate(Bucket=bucket)
+              delete_objects(bucket, result)
+
+
+          def delete_versioned_objects(bucket):
+              print('Collecting data from' + bucket)
+              paginator = client.get_paginator('list_object_versions')
+              result = paginator.paginate(Bucket=bucket)
+              delete_objects(bucket, result)
+
+
+          def delete_objects(bucket, result):
+              objects = []
+              for page in result:
+                  if 'Contents' in page:
+                      for k in page['Contents']:
+                          objects.append({'Key': k['Key']})
+                  if 'Versions' in page:
+                      for k in page['Versions']:
+                          objects.append({'Key': k['Key'], 'VersionId': k['VersionId']})
+                  if 'DeleteMarkers' in page:
+                      for k in page['DeleteMarkers']:
+                          version = k['VersionId']
+                          key = k['Key']
+                          objects.append({'Key': key, 'VersionId': version})
+              print('deleting objects')
+              try:
+                  client.delete_objects(Bucket=bucket, Delete={'Objects': objects})
+              except Exception as e:
+                  logging.error('Exception deleting objects: %s' % e)
+                  raise
+              print('bucket emptied')
+
+
+          def timeout(event, context):
+              logging.error('Lambda execution has timed out, sending failure response to CloudFormation')
+              logging.error('Consider increasing the Lambda execution timeout parameter in the configuration')
+              cfnresponse.send(event, context, cfnresponse.FAILED, {}, None)
+
+
+          def handler(event, context):
+              # make sure we send a failure to CloudFormation if the function is going to timeout
+              timer = threading.Timer((context.get_remaining_time_in_millis() / 1000.00) - 0.5, timeout, args=[event, context])
+              timer.start()
+
+              print('Received event: %s' % json.dumps(event))
+              status = cfnresponse.SUCCESS
+              try:
+                  dest_bucket = event['ResourceProperties']['DestBucket']
+                  if event['RequestType'] == 'Delete':
+                      CheckifVersioned = client.get_bucket_versioning(Bucket=dest_bucket)
+                      print(CheckifVersioned)
+                      if 'Status' in CheckifVersioned:
+                          print(CheckifVersioned['Status'])
+                          print('This is a versioned Bucket')
+                          delete_versioned_objects(dest_bucket)
+                      else:
+                          print('This is not a versioned bucket')
+                          delete_non_versioned_objects(dest_bucket)
+                  else:
+                      print('Nothing to do')
+              except Exception as e:
+                  logging.error('Exception: %s' % e, exc_info=True)
+                  status = cfnresponse.FAILED
+              finally:
+                  timer.cancel()
+                  cfnresponse.send(event, context, status, {}, None)
       Description: Empty the S3 Bucket
       Handler: index.handler
       Role: !GetAtt 
         - S3CleanUpRole
         - Arn
-      Runtime: python2.7
+      Runtime: python3.8
       Timeout: 240
     DependsOn: S3CleanUpRole
     Type: 'AWS::Lambda::Function'
@@ -139,8 +132,8 @@ Resources:
                   - 's3:GetBucketVersioning'
                 Effect: Allow
                 Resource:
-                  - !Sub 'arn:aws:s3:::${BucketName}/*'
-                  - !Sub 'arn:aws:s3:::*'
+                  - !Sub 'arn:${AWS::Partition}:s3:::${BucketName}/*'
+                  - !Sub 'arn:${AWS::Partition}:s3:::*'
             Version: 2012-10-17
           PolicyName: Empty-bucket
     Type: 'AWS::IAM::Role'


### PR DESCRIPTION
Addresses #29

Refactors empty bucket lambda code. Fixes issue of delete markers not being cleaned up. Cleaner exceptions. Python 3.8 compliant.

Threw in a couple ${AWS::Partition} adds as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
