### PR TITLE
Update Python version from 2.7 to 3.9

### DIFF
--- a/templates/copy-lambdas.template
+++ b/templates/copy-lambdas.template
@@ -135,7 +135,7 @@ Resources:
       Role: !GetAtt 
         - CopyObjectsRole
         - Arn
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: 240
     DependsOn:
       - CopyObjectsRole
@@ -286,7 +286,7 @@ Resources:
       Role: !GetAtt 
         - S3CleanUpRole
         - Arn
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: 240
     DependsOn: S3CleanUpRole
     Type: 'AWS::Lambda::Function'


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-quickstart/quickstart-taskcat-ci/issues/37

*Description of changes:*
Deploy failing with this error:
```
The runtime parameter of python2.7 is no longer supported for creating or updating AWS Lambda functions.
We recommend you use the new runtime (python3.9) while creating or updating functions. 
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
